### PR TITLE
Feat: Add env vars for public webhook URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ POSTGRES_PASSWORD=YOUR_SUPER_SECRET_PASSWORD
 # The public-facing hostname for n8n
 N8N_HOST=n8n
 GENERIC_TIMEZONE=Europe/London
+N8N_EDITOR_BASE_URL=https://thebaseurl.domain
+WEBHOOK_URL=https://thebaseurl.domain
 
 # --- Docker Permissions ---
 # User and Group ID for the n8n container to avoid permission issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
       - N8N_HOST=${N8N_HOST}
       - GENERIC_TIMEZONE=${GENERIC_TIMEZONE}
+      - N8N_EDITOR_BASE_URL=${N8N_EDITOR_BASE_URL}
+      - WEBHOOK_URL=${WEBHOOK_URL}
     volumes:
       - ./n8n_data:/home/node/.n8n
     depends_on:


### PR DESCRIPTION
When running n8n locally behind a secure tunnel (e.g., ngrok), external services like Google OAuth cannot use the internal hostname to send callbacks. This results in `redirect_uri_mismatch` errors.

This change introduces support for two key environment variables:
- N8N_EDITOR_BASE_URL
- WEBHOOK_URL

Setting these variables to the public-facing URL provided by the tunnel allows n8n to generate the correct callback URLs, enabling successful authentication with external services.