### PR TITLE
Added the two missing environment variable definition lines into the environment example file

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -6,6 +6,8 @@ POSTGRES_PASSWORD=password
 # n8n Configuration
 N8N_HOST=n8n
 GENERIC_TIMEZONE=Europe/Isle_of_Man
+N8N_EDITOR_BASE_URL=https://domain.tld
+WEBHOOK_URL=https://domain.tld
 
 # Docker-specific settings (optional but good practice)
 # This helps ensure data directories are owned by the right user


### PR DESCRIPTION
N8N_EDITOR_BASE_URL and WEBHOOK_URL were missing from the environment example file.